### PR TITLE
 채팅이 없어도 방 목록은 보이도록 처리 및 Chat entity 수정

### DIFF
--- a/src/main/java/com/clover/youngchat/domain/chat/entity/Chat.java
+++ b/src/main/java/com/clover/youngchat/domain/chat/entity/Chat.java
@@ -1,10 +1,9 @@
 package com.clover.youngchat.domain.chat.entity;
 
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
+import com.clover.youngchat.domain.model.BaseEntity;
 import com.clover.youngchat.domain.user.entity.User;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -12,20 +11,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @Table(name = "chat")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
-public class Chat {
+public class Chat extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,10 +35,6 @@ public class Chat {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatroom_id", nullable = false, updatable = false)
     private ChatRoom chatRoom;
-
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
 
     // TODO: senderName 따로뺐을때 성능차이 어떻게 나는지 확인해보기
 

--- a/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomAndLastChatGetRes.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomAndLastChatGetRes.java
@@ -26,8 +26,8 @@ public class ChatRoomAndLastChatGetRes {
     public static ChatRoomAndLastChatGetRes to(ChatRoom chatRoom, Chat chat) {
         return ChatRoomAndLastChatGetRes.builder()
             .title(chatRoom.getTitle())
-            .lastChat(chat.getMessage())
-            .lastChatTime(chat.getCreatedAt())
+            .lastChat((chat == null) ? null : chat.getMessage())
+            .lastChatTime((chat == null) ? null : chat.getCreatedAt())
             .build();
     }
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomAndLastChatGetRes.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomAndLastChatGetRes.java
@@ -26,8 +26,8 @@ public class ChatRoomAndLastChatGetRes {
     public static ChatRoomAndLastChatGetRes to(ChatRoom chatRoom, Chat chat) {
         return ChatRoomAndLastChatGetRes.builder()
             .title(chatRoom.getTitle())
-            .lastChat((chat == null) ? null : chat.getMessage())
-            .lastChatTime((chat == null) ? null : chat.getCreatedAt())
+            .lastChat((chat == null) ? "" : chat.getMessage())
+            .lastChatTime((chat == null) ? chatRoom.getCreatedAt() : chat.getCreatedAt())
             .build();
     }
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -102,7 +102,7 @@ public class ChatRoomService {
 
         for (ChatRoomUser c : chatRoomUserList) {
             Chat chat = chatRepository.findLastChatByChatRoom_Id(c.getChatRoom().getId())
-                .orElseThrow(() -> new GlobalException(NOT_FOUND_CHAT));
+                .orElse(null);
 
             ChatRoomAndLastChatGetRes res = ChatRoomAndLastChatGetRes.to(c.getChatRoom(), chat);
             getResList.add(res);

--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -100,6 +100,7 @@ public class ChatRoomService {
 
         List<ChatRoomAndLastChatGetRes> getResList = new ArrayList<>();
 
+        // TODO: 차후 로직 수정요함.
         for (ChatRoomUser c : chatRoomUserList) {
             Chat chat = chatRepository.findLastChatByChatRoom_Id(c.getChatRoom().getId())
                 .orElse(null);


### PR DESCRIPTION
## 개요
 채팅이 없어도 방 목록은 보이도록 처리 및 Chat entity 수정

## 작업사항
- 채팅 없어도 방목록 보이도록 ChatRoom Service 로직 수정(차후 로직 수정요함)
- Chat Entity Base Entity 상속받도록 수정

## 관련 이슈             
`해당 Issue 의 체크리스트를 체크해주세요!`
- close #75


  
