### PR TITLE
채팅방 나가기 테스트 코드 추가

### DIFF
--- a/src/test/java/com/clover/youngchat/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chat/service/ChatServiceTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static test.ChatUserTest.TEST_CHAT_USER;
+import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER;
 
 import com.clover.youngchat.domain.chat.constant.ChatConstant;
 import com.clover.youngchat.domain.chat.dto.request.ChatCreateReq;
@@ -64,7 +64,7 @@ class ChatServiceTest implements ChatTest {
                 Optional.of(TEST_CHAT_ROOM));
             given(
                 chatRoomUserRepository.findByChatRoom_IdAndUser_Id(TEST_CHAT_ROOM_ID, TEST_USER_ID))
-                .willReturn(Optional.of(TEST_CHAT_USER));
+                .willReturn(Optional.of(TEST_CHAT_ROOM_USER));
 
             // when
             chatService.createChat(TEST_CHAT_ROOM_ID, req, TEST_USER_ID);

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/controller/ChatRoomControllerTest.java
@@ -2,10 +2,12 @@ package com.clover.youngchat.domain.chatRoom.controller;
 
 import static com.clover.youngchat.global.exception.ResultCode.SUCCESS;
 import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static test.ChatRoomTest.TEST_CHAT_ROOM_ID;
 import static test.ChatRoomTest.TEST_CHAT_ROOM_TITLE;
 
 import com.clover.youngchat.domain.BaseMvcTest;
@@ -35,6 +37,16 @@ public class ChatRoomControllerTest extends BaseMvcTest {
         mockMvc.perform(post("/api/v1/chat-rooms")
                 .content(objectMapper.writeValueAsString(req))
                 .contentType(MediaType.APPLICATION_JSON)
+                .principal(mockPrincipal))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code", is(SUCCESS.getCode())))
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("채팅방 나가기 테스트 : 성공")
+    void leaveChatRoom() throws Exception {
+        mockMvc.perform(delete("/api/v1/chat-rooms/" + TEST_CHAT_ROOM_ID)
                 .principal(mockPrincipal))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.code", is(SUCCESS.getCode())))

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -1,5 +1,6 @@
 package com.clover.youngchat.domain.chatRoom.service;
 
+import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_CHATROOM;
 import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -121,6 +122,17 @@ public class ChatRoomServiceTest {
             verify(chatRoomRepository,times(1)).existsById(anyLong());
             verify(chatRoomUserRepository, times(1)).findByChatRoom_IdAndUser_Id(anyLong(),anyLong());
             verify(chatRoomUserRepository,times(1)).delete(any());
+        }
+
+        @Test
+        @DisplayName("실패 : 존재하지 않는 채팅방")
+        void leaveChatRoomFail_NotFoundChatRoom(){
+            given(chatRoomRepository.existsById(anyLong())).willReturn(false);
+
+            GlobalException exception = Assertions.assertThrows(GlobalException.class,
+                ()-> chatRoomService.leaveChatRoom(TEST_CHAT_ROOM_ID, user));
+
+            assertThat(exception.getResultCode().getMessage()).isEqualTo(NOT_FOUND_CHATROOM.getMessage());
         }
     }
 }

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -1,14 +1,21 @@
 package com.clover.youngchat.domain.chatRoom.service;
 
+import static com.clover.youngchat.global.exception.ResultCode.ACCESS_DENY;
 import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_CHATROOM;
 import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_USER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static test.ChatRoomTest.*;
+import static test.ChatRoomTest.TEST_CHAT_ROOM_ID;
+import static test.ChatRoomTest.TEST_CHAT_ROOM_TITLE;
+import static test.ChatRoomTest.TEST_USER_EMAIL;
+import static test.ChatRoomTest.TEST_USER_NAME;
+import static test.ChatRoomTest.TEST_USER_PASSWORD;
+import static test.ChatRoomTest.TEST_USER_PROFILE_IMAGE;
 import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER;
 import static test.UserTest.ANOTHER_TEST_USER_ID;
 import static test.UserTest.TEST_USER;
@@ -22,7 +29,6 @@ import com.clover.youngchat.domain.user.entity.User;
 import com.clover.youngchat.domain.user.repository.UserRepository;
 import com.clover.youngchat.global.exception.GlobalException;
 import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -100,7 +106,7 @@ public class ChatRoomServiceTest {
 
             given(userRepository.findById(anyLong())).willReturn(Optional.empty());
 
-            GlobalException exception = Assertions.assertThrows(GlobalException.class,
+            GlobalException exception = assertThrows(GlobalException.class,
                 () -> chatRoomService.createChatRoom(req, TEST_USER));
 
             assertThat(exception.getResultCode().getMessage()).isEqualTo(
@@ -129,10 +135,22 @@ public class ChatRoomServiceTest {
         void leaveChatRoomFail_NotFoundChatRoom(){
             given(chatRoomRepository.existsById(anyLong())).willReturn(false);
 
-            GlobalException exception = Assertions.assertThrows(GlobalException.class,
+            GlobalException exception = assertThrows(GlobalException.class,
                 ()-> chatRoomService.leaveChatRoom(TEST_CHAT_ROOM_ID, user));
 
             assertThat(exception.getResultCode().getMessage()).isEqualTo(NOT_FOUND_CHATROOM.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패 : 채팅방에 속한 유저가 아닐 경우")
+        void leaveChatRoomFail_AccessDeny(){
+            given(chatRoomRepository.existsById(anyLong())).willReturn(true);
+            given(chatRoomUserRepository.findByChatRoom_IdAndUser_Id(anyLong(), anyLong())).willReturn(Optional.empty());
+
+            GlobalException exception = assertThrows(GlobalException.class,
+                ()-> chatRoomService.leaveChatRoom(TEST_CHAT_ROOM_ID, user));
+
+            assertThat(exception.getResultCode().getMessage()).isEqualTo(ACCESS_DENY.getMessage());
         }
     }
 }

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -7,7 +7,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static test.ChatRoomTest.TEST_CHAT_ROOM_TITLE;
+import static test.ChatRoomTest.*;
+import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER;
 import static test.UserTest.ANOTHER_TEST_USER_ID;
 import static test.UserTest.TEST_USER;
 
@@ -16,6 +17,7 @@ import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
 import com.clover.youngchat.domain.chatroom.repository.ChatRoomRepository;
 import com.clover.youngchat.domain.chatroom.repository.ChatRoomUserRepository;
 import com.clover.youngchat.domain.chatroom.service.ChatRoomService;
+import com.clover.youngchat.domain.user.entity.User;
 import com.clover.youngchat.domain.user.repository.UserRepository;
 import com.clover.youngchat.global.exception.GlobalException;
 import java.util.Optional;
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class ChatRoomServiceTest {
@@ -46,11 +49,23 @@ public class ChatRoomServiceTest {
 
     private ChatRoom chatRoom;
 
+    private User user;
+
     @BeforeEach
     void setup() {
         chatRoom = ChatRoom.builder()
             .title(TEST_CHAT_ROOM_TITLE)
             .build();
+        ReflectionTestUtils.setField(chatRoom, "id", 1L);
+
+        user = User.builder()
+            .username(TEST_USER_NAME)
+            .email(TEST_USER_EMAIL)
+            .profileImage(TEST_USER_PROFILE_IMAGE)
+            .password(TEST_USER_PASSWORD)
+            .build();
+
+        ReflectionTestUtils.setField(user, "id", 1L);
     }
 
     @Nested
@@ -89,6 +104,23 @@ public class ChatRoomServiceTest {
 
             assertThat(exception.getResultCode().getMessage()).isEqualTo(
                 NOT_FOUND_USER.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅방 나가기")
+    class leaveChatRoom {
+        @Test
+        @DisplayName("성공")
+        void leaveChatRoomSuccess(){
+            given(chatRoomRepository.existsById(anyLong())).willReturn(true);
+            given(chatRoomUserRepository.findByChatRoom_IdAndUser_Id(anyLong(), anyLong())).willReturn(Optional.of(TEST_CHAT_ROOM_USER));
+
+            chatRoomService.leaveChatRoom(TEST_CHAT_ROOM_ID, user);
+
+            verify(chatRoomRepository,times(1)).existsById(anyLong());
+            verify(chatRoomUserRepository, times(1)).findByChatRoom_IdAndUser_Id(anyLong(),anyLong());
+            verify(chatRoomUserRepository,times(1)).delete(any());
         }
     }
 }

--- a/src/test/java/test/ChatRoomUserTest.java
+++ b/src/test/java/test/ChatRoomUserTest.java
@@ -2,11 +2,11 @@ package test;
 
 import com.clover.youngchat.domain.chatroom.entity.ChatRoomUser;
 
-public interface ChatUserTest extends UserTest, ChatRoomTest {
+public interface ChatRoomUserTest extends UserTest, ChatRoomTest {
 
     Long TEST_CHAT_USER_ID = 1L;
 
-    ChatRoomUser TEST_CHAT_USER = ChatRoomUser.builder()
+    ChatRoomUser TEST_CHAT_ROOM_USER = ChatRoomUser.builder()
         .user(TEST_USER)
         .chatRoom(TEST_CHAT_ROOM)
         .build();


### PR DESCRIPTION
## 개요
채팅방 나가기 테스트 코드를 추가합니다.

## 작업사항
- 채팅방 나가기 서비스 테스트 코드 추가
- 채팅방 나가기 컨트롤러 테스트 코드 추가
- ChatRoom과 User의 다대다 연결 중간 테이블인 ChatUser는 채팅과 유저 다대다 매핑의 중간 테이블로 오해할 수 있는 여지가 충분하다고 생각하여 이전에 이름을 변경했었음
- 위 부분이 테스트 코드에는 적용되지 않아, ChatUserTest -> ChatRoomUserTest로 변경하였음
- 이에 따라 ChatServiceTest 코드에도 변수명 변경이 적용됨

## 관련 이슈             
레포지토리 테스트는 우선순위가 가장 낮다고 판단하여, 추후 추가할 예정입니다.
- close #78 


  
