### PR TITLE
채팅방 수정 테스트 코드 추가

### DIFF
--- a/src/test/java/com/clover/youngchat/domain/chatRoom/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/controller/ChatRoomControllerTest.java
@@ -2,6 +2,7 @@ package com.clover.youngchat.domain.chatRoom.controller;
 
 import static com.clover.youngchat.global.exception.ResultCode.SUCCESS;
 import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -13,6 +14,7 @@ import static test.ChatRoomTest.TEST_CHAT_ROOM_TITLE;
 import com.clover.youngchat.domain.BaseMvcTest;
 import com.clover.youngchat.domain.chatroom.controller.ChatRoomController;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomCreateReq;
+import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomEditReq;
 import com.clover.youngchat.domain.chatroom.service.ChatRoomService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,22 @@ public class ChatRoomControllerTest extends BaseMvcTest {
             .build();
 
         mockMvc.perform(post("/api/v1/chat-rooms")
+                .content(objectMapper.writeValueAsString(req))
+                .contentType(MediaType.APPLICATION_JSON)
+                .principal(mockPrincipal))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code", is(SUCCESS.getCode())))
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("채팅방 수정 테스트 : 성공")
+    void editChatRoom() throws Exception {
+        ChatRoomEditReq req = ChatRoomEditReq.builder()
+            .title(TEST_CHAT_ROOM_TITLE)
+            .build();
+
+        mockMvc.perform(patch("/api/v1/chat-rooms/" + TEST_CHAT_ROOM_ID)
                 .content(objectMapper.writeValueAsString(req))
                 .contentType(MediaType.APPLICATION_JSON)
                 .principal(mockPrincipal))

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/repository/ChatRoomRepositoryTest.java
@@ -2,11 +2,13 @@ package com.clover.youngchat.domain.chatRoom.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static test.ChatRoomTest.TEST_CHAT_ROOM;
+import static test.ChatRoomTest.TEST_CHAT_ROOM_ID;
 import static test.ChatRoomTest.TEST_CHAT_ROOM_TITLE;
 
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
 import com.clover.youngchat.domain.chatroom.repository.ChatRoomRepository;
 import com.clover.youngchat.global.config.QueryDslConfig;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,5 +32,16 @@ public class ChatRoomRepositoryTest {
         ChatRoom chatRoom = chatRoomRepository.save(TEST_CHAT_ROOM);
 
         assertThat(chatRoom.getTitle()).isEqualTo(TEST_CHAT_ROOM_TITLE);
+    }
+
+    @Test
+    @DisplayName("findById 테스트")
+    void findByIdTest() {
+        chatRoomRepository.save(TEST_CHAT_ROOM);
+
+        Optional<ChatRoom> chatRoom = chatRoomRepository.findById(TEST_CHAT_ROOM_ID);
+
+        assertThat(chatRoom.get().getId()).isEqualTo(TEST_CHAT_ROOM_ID);
+        assertThat(chatRoom.get().getTitle()).isEqualTo(TEST_CHAT_ROOM_TITLE);
     }
 }

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/repository/ChatRoomRepositoryTest.java
@@ -2,13 +2,11 @@ package com.clover.youngchat.domain.chatRoom.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static test.ChatRoomTest.TEST_CHAT_ROOM;
-import static test.ChatRoomTest.TEST_CHAT_ROOM_ID;
 import static test.ChatRoomTest.TEST_CHAT_ROOM_TITLE;
 
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
 import com.clover.youngchat.domain.chatroom.repository.ChatRoomRepository;
 import com.clover.youngchat.global.config.QueryDslConfig;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,16 +30,5 @@ public class ChatRoomRepositoryTest {
         ChatRoom chatRoom = chatRoomRepository.save(TEST_CHAT_ROOM);
 
         assertThat(chatRoom.getTitle()).isEqualTo(TEST_CHAT_ROOM_TITLE);
-    }
-
-    @Test
-    @DisplayName("findById 테스트")
-    void findByIdTest() {
-        chatRoomRepository.save(TEST_CHAT_ROOM);
-
-        Optional<ChatRoom> chatRoom = chatRoomRepository.findById(TEST_CHAT_ROOM_ID);
-
-        assertThat(chatRoom.get().getId()).isEqualTo(TEST_CHAT_ROOM_ID);
-        assertThat(chatRoom.get().getTitle()).isEqualTo(TEST_CHAT_ROOM_TITLE);
     }
 }

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -47,7 +47,6 @@ public class ChatRoomServiceTest implements ChatRoomTest {
     private ChatRoomUserRepository chatRoomUserRepository;
 
     private ChatRoom chatRoom;
-
     private User user;
 
     @BeforeEach
@@ -55,13 +54,14 @@ public class ChatRoomServiceTest implements ChatRoomTest {
         chatRoom = ChatRoom.builder()
             .title(TEST_CHAT_ROOM_TITLE)
             .build();
+
         ReflectionTestUtils.setField(chatRoom, "id", TEST_CHAT_ROOM_ID);
 
         user = User.builder()
             .username(TEST_USER_NAME)
             .email(TEST_USER_EMAIL)
-            .profileImage(TEST_USER_PROFILE_IMAGE)
             .password(TEST_USER_PASSWORD)
+            .profileImage(TEST_USER_PROFILE_IMAGE)
             .build();
 
         ReflectionTestUtils.setField(user, "id", TEST_USER_ID);
@@ -151,7 +151,7 @@ public class ChatRoomServiceTest implements ChatRoomTest {
     class editChatRoom {
 
         @Test
-        @DisplayName("채팅방 수정 성공")
+        @DisplayName("성공")
         void editChatRoomSuccess() {
             ChatRoomEditReq req = ChatRoomEditReq.builder()
                 .title("채팅방 수정")
@@ -164,6 +164,22 @@ public class ChatRoomServiceTest implements ChatRoomTest {
             chatRoomService.editChatRoom(TEST_CHAT_ROOM_ID, req, user);
 
             assertThat(chatRoom.getTitle()).isEqualTo(req.getTitle());
+        }
+
+        @Test
+        @DisplayName("실패 : 존재하지 않는 채팅방")
+        void editChatRoomFail_NotFoundChatRoom() {
+            ChatRoomEditReq req = ChatRoomEditReq.builder()
+                .title("채팅방 수정")
+                .build();
+
+            given(chatRoomRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            GlobalException exception = assertThrows(GlobalException.class, () ->
+                chatRoomService.editChatRoom(TEST_CHAT_ROOM_ID, req, user));
+
+            assertThat(exception.getResultCode().getMessage()).isEqualTo(
+                NOT_FOUND_CHATROOM.getMessage());
         }
     }
 }

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -181,5 +181,23 @@ public class ChatRoomServiceTest implements ChatRoomTest {
             assertThat(exception.getResultCode().getMessage()).isEqualTo(
                 NOT_FOUND_CHATROOM.getMessage());
         }
+
+        @Test
+        @DisplayName("실패 : 채팅방의 멤버가 아닐 경우")
+        void editChatRoomFail_AccessDeny() {
+            ChatRoomEditReq req = ChatRoomEditReq.builder()
+                .title("채팅방 수정")
+                .build();
+
+            given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(chatRoom));
+            given(chatRoomUserRepository.existsByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong())).willReturn(false);
+
+            GlobalException exception = assertThrows(GlobalException.class, () ->
+                chatRoomService.editChatRoom(TEST_CHAT_ROOM_ID, req, user));
+
+            assertThat(exception.getResultCode().getMessage()).isEqualTo(
+                ACCESS_DENY.getMessage());
+        }
     }
 }

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -10,6 +10,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER;
+
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomCreateReq;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomEditReq;
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
@@ -109,38 +111,43 @@ public class ChatRoomServiceTest implements ChatRoomTest {
     @Nested
     @DisplayName("채팅방 나가기")
     class leaveChatRoom {
+
         @Test
         @DisplayName("성공")
-        void leaveChatRoomSuccess(){
+        void leaveChatRoomSuccess() {
             given(chatRoomRepository.existsById(anyLong())).willReturn(true);
-            given(chatRoomUserRepository.findByChatRoom_IdAndUser_Id(anyLong(), anyLong())).willReturn(Optional.of(TEST_CHAT_ROOM_USER));
+            given(chatRoomUserRepository.findByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong())).willReturn(Optional.of(TEST_CHAT_ROOM_USER));
 
             chatRoomService.leaveChatRoom(TEST_CHAT_ROOM_ID, user);
 
-            verify(chatRoomRepository,times(1)).existsById(anyLong());
-            verify(chatRoomUserRepository, times(1)).findByChatRoom_IdAndUser_Id(anyLong(),anyLong());
-            verify(chatRoomUserRepository,times(1)).delete(any());
+            verify(chatRoomRepository, times(1)).existsById(anyLong());
+            verify(chatRoomUserRepository, times(1)).findByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong());
+            verify(chatRoomUserRepository, times(1)).delete(any());
         }
 
         @Test
         @DisplayName("실패 : 존재하지 않는 채팅방")
-        void leaveChatRoomFail_NotFoundChatRoom(){
+        void leaveChatRoomFail_NotFoundChatRoom() {
             given(chatRoomRepository.existsById(anyLong())).willReturn(false);
 
             GlobalException exception = assertThrows(GlobalException.class,
-                ()-> chatRoomService.leaveChatRoom(TEST_CHAT_ROOM_ID, user));
+                () -> chatRoomService.leaveChatRoom(TEST_CHAT_ROOM_ID, user));
 
-            assertThat(exception.getResultCode().getMessage()).isEqualTo(NOT_FOUND_CHATROOM.getMessage());
+            assertThat(exception.getResultCode().getMessage()).isEqualTo(
+                NOT_FOUND_CHATROOM.getMessage());
         }
 
         @Test
         @DisplayName("실패 : 채팅방에 속한 유저가 아닐 경우")
-        void leaveChatRoomFail_AccessDeny(){
+        void leaveChatRoomFail_AccessDeny() {
             given(chatRoomRepository.existsById(anyLong())).willReturn(true);
-            given(chatRoomUserRepository.findByChatRoom_IdAndUser_Id(anyLong(), anyLong())).willReturn(Optional.empty());
+            given(chatRoomUserRepository.findByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong())).willReturn(Optional.empty());
 
             GlobalException exception = assertThrows(GlobalException.class,
-                ()-> chatRoomService.leaveChatRoom(TEST_CHAT_ROOM_ID, user));
+                () -> chatRoomService.leaveChatRoom(TEST_CHAT_ROOM_ID, user));
 
             assertThat(exception.getResultCode().getMessage()).isEqualTo(ACCESS_DENY.getMessage());
         }

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -10,17 +10,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static test.ChatRoomTest.TEST_CHAT_ROOM_ID;
-import static test.ChatRoomTest.TEST_CHAT_ROOM_TITLE;
-import static test.ChatRoomTest.TEST_USER_EMAIL;
-import static test.ChatRoomTest.TEST_USER_NAME;
-import static test.ChatRoomTest.TEST_USER_PASSWORD;
-import static test.ChatRoomTest.TEST_USER_PROFILE_IMAGE;
-import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER;
-import static test.UserTest.ANOTHER_TEST_USER_ID;
-import static test.UserTest.TEST_USER;
-
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomCreateReq;
+import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomEditReq;
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
 import com.clover.youngchat.domain.chatroom.repository.ChatRoomRepository;
 import com.clover.youngchat.domain.chatroom.repository.ChatRoomUserRepository;
@@ -38,9 +29,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import test.ChatRoomTest;
 
 @ExtendWith(MockitoExtension.class)
-public class ChatRoomServiceTest {
+public class ChatRoomServiceTest implements ChatRoomTest {
 
     @InjectMocks
     private ChatRoomService chatRoomService;
@@ -63,7 +55,7 @@ public class ChatRoomServiceTest {
         chatRoom = ChatRoom.builder()
             .title(TEST_CHAT_ROOM_TITLE)
             .build();
-        ReflectionTestUtils.setField(chatRoom, "id", 1L);
+        ReflectionTestUtils.setField(chatRoom, "id", TEST_CHAT_ROOM_ID);
 
         user = User.builder()
             .username(TEST_USER_NAME)
@@ -72,7 +64,7 @@ public class ChatRoomServiceTest {
             .password(TEST_USER_PASSWORD)
             .build();
 
-        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "id", TEST_USER_ID);
     }
 
     @Nested
@@ -151,6 +143,27 @@ public class ChatRoomServiceTest {
                 ()-> chatRoomService.leaveChatRoom(TEST_CHAT_ROOM_ID, user));
 
             assertThat(exception.getResultCode().getMessage()).isEqualTo(ACCESS_DENY.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅방 수정")
+    class editChatRoom {
+
+        @Test
+        @DisplayName("채팅방 수정 성공")
+        void editChatRoomSuccess() {
+            ChatRoomEditReq req = ChatRoomEditReq.builder()
+                .title("채팅방 수정")
+                .build();
+
+            given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(chatRoom));
+            given(chatRoomUserRepository.existsByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong())).willReturn(true);
+
+            chatRoomService.editChatRoom(TEST_CHAT_ROOM_ID, req, user);
+
+            assertThat(chatRoom.getTitle()).isEqualTo(req.getTitle());
         }
     }
 }


### PR DESCRIPTION
## 개요
채팅방 수정 기능 테스트 코드를 구현합니다.

## 작업사항
- 채팅방 수정 서비스 테스트 추가
- 채팅방 수정 컨트롤러 테스트 추가

## 관련 이슈
- 채팅방 수정 레포지토리 테스트 구현 중, `findById` 단독으로 실행 시 성공, 전체 실행 시 ID값 null 이슈 발생하여 임시 제외
- 추후 레포지토리 테스트 코드 추가 시 같이 해결할 예정
             
- close #68 


  
