### PR TITLE
채팅방 목록 조회 테스트 코드 추가

### DIFF
--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -116,14 +116,13 @@ public class ChatRoomService {
     public ChatRoomDetailGetRes getDetailChatRoom(Long chatRoomId, User user) {
         // 채팅방에 속한 사람만 조회 가능
         isChatRoomMember(chatRoomId, user.getId());
+        ChatRoom chatRoom = findById(chatRoomId);
 
         List<ChatRes> chatList = chatRepository.findAllByChatRoom_Id(chatRoomId)
             .orElseThrow(() -> new GlobalException(NOT_FOUND_CHAT))
             .stream()
             .map(ChatRes::to)
             .toList();
-
-        ChatRoom chatRoom = findById(chatRoomId);
 
         return ChatRoomDetailGetRes.builder()
             .title(chatRoom.getTitle())

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/controller/ChatRoomControllerTest.java
@@ -81,4 +81,14 @@ public class ChatRoomControllerTest extends BaseMvcTest {
             .andExpect(jsonPath("$.code", is(SUCCESS.getCode())))
             .andDo(print());
     }
+
+    @Test
+    @DisplayName("채팅방 상세 조회 테스트 : 성공")
+    void getDetailChatRoom() throws Exception {
+        mockMvc.perform(get("/api/v1/chat-rooms/" + TEST_CHAT_ROOM_ID)
+                .principal(mockPrincipal))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code", is(SUCCESS.getCode())))
+            .andDo(print());
+    }
 }

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/controller/ChatRoomControllerTest.java
@@ -2,8 +2,9 @@ package com.clover.youngchat.domain.chatRoom.controller;
 
 import static com.clover.youngchat.global.exception.ResultCode.SUCCESS;
 import static org.hamcrest.Matchers.is;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -65,6 +66,16 @@ public class ChatRoomControllerTest extends BaseMvcTest {
     @DisplayName("채팅방 나가기 테스트 : 성공")
     void leaveChatRoom() throws Exception {
         mockMvc.perform(delete("/api/v1/chat-rooms/" + TEST_CHAT_ROOM_ID)
+                .principal(mockPrincipal))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code", is(SUCCESS.getCode())))
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("채팅방 목록 조회 테스트 : 성공")
+    void getChatRoomList() throws Exception {
+        mockMvc.perform(get("/api/v1/chat-rooms")
                 .principal(mockPrincipal))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.code", is(SUCCESS.getCode())))

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -147,6 +147,18 @@ public class ChatRoomServiceTest implements ChatRoomTest {
             assertThat(resList.get(0).getLastChat()).isEqualTo(TEST_CHAT.getMessage());
             assertThat(resList.get(0).getLastChatTime()).isEqualTo(TEST_CHAT.getCreatedAt());
         }
+
+        @Test
+        @DisplayName("실패 : 속한 채팅방이 없는 경우")
+        void getChatRoomListFail_NotFoundChatRoom() {
+            given(chatRoomUserRepository.findByUser_Id(anyLong())).willReturn(Optional.empty());
+
+            GlobalException exception = assertThrows(GlobalException.class,
+                () -> chatRoomService.getChatRoomList(user));
+
+            assertThat(exception.getResultCode().getMessage()).isEqualTo(
+                NOT_FOUND_CHATROOM.getMessage());
+        }
     }
 
     @Nested

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -204,6 +204,22 @@ public class ChatRoomServiceTest implements ChatRoomTest {
                 anyLong());
             assertThat(exception.getResultCode().getMessage()).isEqualTo(ACCESS_DENY.getMessage());
         }
+
+        @Test
+        @DisplayName("실패 : 존재하지 않는 채팅방")
+        void getDetailChatRoomFail_NotFoundChatRoom() {
+            given(chatRoomUserRepository.existsByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong())).willReturn(true);
+            given(chatRoomRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            GlobalException exception = assertThrows(GlobalException.class, () ->
+                chatRoomService.getDetailChatRoom(TEST_CHAT_ROOM_ID, user));
+
+            verify(chatRoomRepository, times(1)).findById(anyLong());
+            assertThat(exception.getResultCode().getMessage()).isEqualTo(
+                NOT_FOUND_CHATROOM.getMessage());
+        }
+
     }
 
     @Nested

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -1,6 +1,7 @@
 package com.clover.youngchat.domain.chatRoom.service;
 
 import static com.clover.youngchat.global.exception.ResultCode.ACCESS_DENY;
+import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_CHAT;
 import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_CHATROOM;
 import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_USER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -220,6 +221,25 @@ public class ChatRoomServiceTest implements ChatRoomTest {
                 NOT_FOUND_CHATROOM.getMessage());
         }
 
+        @Test
+        @DisplayName("실패 : 채팅이 없는 경우")
+        void getDetailChatRoomFail_NotFoundChat() {
+            given(chatRoomUserRepository.existsByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong())).willReturn(true);
+            given(chatRepository.findAllByChatRoom_Id(anyLong())).willReturn(Optional.empty());
+            given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(chatRoom));
+
+            GlobalException exception = assertThrows(GlobalException.class, () ->
+                chatRoomService.getDetailChatRoom(TEST_CHAT_ROOM_ID, user));
+
+            verify(chatRoomUserRepository, times(1)).existsByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong());
+            verify(chatRoomRepository, times(1)).findById(anyLong());
+            verify(chatRepository, times(1)).findAllByChatRoom_Id(anyLong());
+
+            assertThat(exception.getResultCode().getMessage()).isEqualTo(
+                NOT_FOUND_CHAT.getMessage());
+        }
     }
 
     @Nested

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER;
 import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER_LIST;
+import static test.ChatTest.TEST_CHAT;
+import static test.ChatTest.TEST_CHAT_LIST;
 import static test.ChatTest.TEST_CHAT_MESSAGE;
 
 import com.clover.youngchat.domain.chat.entity.Chat;
@@ -19,6 +21,7 @@ import com.clover.youngchat.domain.chat.repository.ChatRepository;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomCreateReq;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomEditReq;
 import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomAndLastChatGetRes;
+import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomDetailGetRes;
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
 import com.clover.youngchat.domain.chatroom.repository.ChatRoomRepository;
 import com.clover.youngchat.domain.chatroom.repository.ChatRoomUserRepository;
@@ -157,6 +160,35 @@ public class ChatRoomServiceTest implements ChatRoomTest {
 
             assertThat(exception.getResultCode().getMessage()).isEqualTo(
                 NOT_FOUND_CHATROOM.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅방 상세 조회")
+    class getDetailChatRoom {
+
+        @Test
+        @DisplayName("성공")
+        void getDetailChatRoomSuccess() {
+            // given
+            given(chatRoomUserRepository.existsByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong())).willReturn(true);
+            given(chatRepository.findAllByChatRoom_Id(anyLong())).willReturn(
+                Optional.of(TEST_CHAT_LIST));
+            given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(chatRoom));
+
+            // when
+            ChatRoomDetailGetRes res = chatRoomService.getDetailChatRoom(TEST_CHAT_ROOM_ID, user);
+
+            // then
+            verify(chatRoomUserRepository, times(1)).existsByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong());
+            verify(chatRepository, times(1)).findAllByChatRoom_Id(anyLong());
+
+            assertThat(res.getChatResList().get(0).getMessage()).isEqualTo(TEST_CHAT.getMessage());
+            assertThat(res.getChatResList().get(0).getMessageTime()).isEqualTo(
+                TEST_CHAT.getCreatedAt());
+            assertThat(res.getChatResList().get(0).getUsername()).isEqualTo(user.getUsername());
         }
     }
 

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER;
 import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER_LIST;
-import static test.ChatTest.TEST_CHAT;
 import static test.ChatTest.TEST_CHAT_MESSAGE;
 
 import com.clover.youngchat.domain.chat.entity.Chat;
@@ -143,9 +142,9 @@ public class ChatRoomServiceTest implements ChatRoomTest {
             verify(chatRoomUserRepository, times(1)).findByUser_Id(anyLong());
             verify(chatRepository, times(2)).findLastChatByChatRoom_Id(any());
 
-            assertThat(resList.get(0).getTitle()).isEqualTo(TEST_CHAT.getChatRoom().getTitle());
-            assertThat(resList.get(0).getLastChat()).isEqualTo(TEST_CHAT.getMessage());
-            assertThat(resList.get(0).getLastChatTime()).isEqualTo(TEST_CHAT.getCreatedAt());
+            assertThat(resList.get(0).getTitle()).isEqualTo(chat.getChatRoom().getTitle());
+            assertThat(resList.get(0).getLastChat()).isEqualTo(chat.getMessage());
+            assertThat(resList.get(0).getLastChatTime()).isEqualTo(chat.getCreatedAt());
         }
 
         @Test

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -190,6 +190,20 @@ public class ChatRoomServiceTest implements ChatRoomTest {
                 TEST_CHAT.getCreatedAt());
             assertThat(res.getChatResList().get(0).getUsername()).isEqualTo(user.getUsername());
         }
+
+        @Test
+        @DisplayName("실패 : 채팅방 멤버가 아닐 경우")
+        void getDetailChatRoomFail_AccessDeny() {
+            given(chatRoomUserRepository.existsByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong())).willReturn(false);
+
+            GlobalException exception = assertThrows(GlobalException.class, () ->
+                chatRoomService.getDetailChatRoom(TEST_CHAT_ROOM_ID, user));
+
+            verify(chatRoomUserRepository, times(1)).existsByChatRoom_IdAndUser_Id(anyLong(),
+                anyLong());
+            assertThat(exception.getResultCode().getMessage()).isEqualTo(ACCESS_DENY.getMessage());
+        }
     }
 
     @Nested

--- a/src/test/java/test/ChatRoomUserTest.java
+++ b/src/test/java/test/ChatRoomUserTest.java
@@ -1,13 +1,25 @@
 package test;
 
 import com.clover.youngchat.domain.chatroom.entity.ChatRoomUser;
+import java.util.Arrays;
+import java.util.List;
 
 public interface ChatRoomUserTest extends UserTest, ChatRoomTest {
 
-    Long TEST_CHAT_USER_ID = 1L;
+    Long TEST_CHAT_ROOM_USER_ID = 1L;
+    Long TEST_ANOTHER_CHAT_ROOM_USER_ID = 2L;
 
     ChatRoomUser TEST_CHAT_ROOM_USER = ChatRoomUser.builder()
         .user(TEST_USER)
         .chatRoom(TEST_CHAT_ROOM)
         .build();
+
+    ChatRoomUser TEST_ANOTHER_CHAT_ROOM_USER = ChatRoomUser.builder()
+        .user(TEST_ANOTHER_USER)
+        .chatRoom(TEST_ANOTHER_CHAT_ROOM)
+        .build();
+
+    List<ChatRoomUser> TEST_CHAT_ROOM_USER_LIST = Arrays.asList(TEST_CHAT_ROOM_USER,
+        TEST_ANOTHER_CHAT_ROOM_USER);
+
 }

--- a/src/test/java/test/ChatTest.java
+++ b/src/test/java/test/ChatTest.java
@@ -1,6 +1,8 @@
 package test;
 
 import com.clover.youngchat.domain.chat.entity.Chat;
+import java.util.Arrays;
+import java.util.List;
 
 public interface ChatTest extends UserTest, ChatRoomTest {
 
@@ -21,4 +23,6 @@ public interface ChatTest extends UserTest, ChatRoomTest {
         .sender(TEST_ANOTHER_USER)
         .chatRoom(TEST_ANOTHER_CHAT_ROOM)
         .build();
+
+    List<Chat> TEST_CHAT_LIST = Arrays.asList(TEST_CHAT, TEST_ANOTHER_CHAT);
 }


### PR DESCRIPTION
## 개요
채팅방 목록 조회 테스트 코드를 추가합니다.
채팅방 상세 조회 테스트 코드를 추가합니다.
채팅방 상세 조회 서비스 로직 순서를 일부 변경합니다.

## 작업사항
- 채팅방 목록 조회 서비스 테스트 추가
- 채팅방 목록 조회 컨트롤러 테스트 추가
- 채팅방 상세 조회 서비스 테스트 추가
- 채팅방 상세 조회 컨트롤러 테스트 추가
- 채팅방 상세 조회 서비스 로직 `ChatRoom chatRoom = findById` 순서 변경

## 관련 이슈             
- close #80
- close #81 
- close #85 


  
