### PR TITLE
Refactor: 채팅방 상세목록 조회시 채팅Res에 username대신 userId로 변경

### DIFF
--- a/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomDetailGetRes.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomDetailGetRes.java
@@ -26,21 +26,21 @@ public class ChatRoomDetailGetRes {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class ChatRes {
 
+        Long userId;
         String message;
-        String username;
         LocalDateTime messageTime;
 
         @Builder
-        private ChatRes(String message, String username, LocalDateTime messageTime) {
+        private ChatRes(Long userId, String message, LocalDateTime messageTime) {
+            this.userId = userId;
             this.message = message;
-            this.username = username;
             this.messageTime = messageTime;
         }
 
         public static ChatRes to(Chat chat) {
             return ChatRes.builder()
+                .userId(chat.getSender().getId())
                 .message(chat.getMessage())
-                .username(chat.getSender().getUsername())
                 .messageTime(chat.getCreatedAt())
                 .build();
         }

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -189,7 +189,6 @@ public class ChatRoomServiceTest implements ChatRoomTest {
             assertThat(res.getChatResList().get(0).getMessage()).isEqualTo(TEST_CHAT.getMessage());
             assertThat(res.getChatResList().get(0).getMessageTime()).isEqualTo(
                 TEST_CHAT.getCreatedAt());
-            assertThat(res.getChatResList().get(0).getUsername()).isEqualTo(user.getUsername());
         }
 
         @Test


### PR DESCRIPTION
## 개요
 채팅방 상세목록 조회시 채팅Res에 username대신 userId로 변경

## 작업사항
-  채팅방 상세목록 조회시 채팅Res에 username대신 userId로 변경
- 테스트 코드 일부 수정

## 관련 이슈             
`해당 Issue 의 체크리스트를 체크해주세요!`
- close #94


  
