### PR TITLE
채팅방 생성 로직 및 reqDto 수정

### DIFF
--- a/src/main/java/com/clover/youngchat/domain/chat/entity/Chat.java
+++ b/src/main/java/com/clover/youngchat/domain/chat/entity/Chat.java
@@ -1,7 +1,5 @@
 package com.clover.youngchat.domain.chat.entity;
 
-import static com.clover.youngchat.domain.chat.constant.ChatConstant.DELETE_MESSAGE;
-
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
 import com.clover.youngchat.domain.model.BaseEntity;
 import com.clover.youngchat.domain.user.entity.User;
@@ -27,7 +25,7 @@ public class Chat extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
+    private boolean isDeleted = false;
     private String message;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -48,6 +46,6 @@ public class Chat extends BaseEntity {
     }
 
     public void deleteChat() {
-        this.message = DELETE_MESSAGE;
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/controller/ChatRoomController.java
@@ -31,7 +31,7 @@ public class ChatRoomController {
     private final ChatRoomService chatRoomService;
 
     @PostMapping
-    public RestResponse<ChatRoomCreateRes> createChatRoom(@RequestBody @Valid ChatRoomCreateReq req,
+    public RestResponse<ChatRoomCreateRes> createChatRoom(@RequestBody ChatRoomCreateReq req,
         @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return RestResponse.success(
             chatRoomService.createChatRoom(req, userDetails.getUser()));

--- a/src/main/java/com/clover/youngchat/domain/chatroom/dto/request/ChatRoomCreateReq.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/dto/request/ChatRoomCreateReq.java
@@ -1,8 +1,6 @@
 package com.clover.youngchat.domain.chatroom.dto.request;
 
-import static com.clover.youngchat.domain.chatroom.constant.ChatRoomConstant.NOT_NULL_CHATROOM_TITLE;
-
-import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,14 +10,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoomCreateReq {
 
-    private Long friendId;
-
-    @NotNull(message = NOT_NULL_CHATROOM_TITLE)
+    private List<Long> friendIds;
     private String title;
 
     @Builder
-    private ChatRoomCreateReq(Long friendId, String title) {
-        this.friendId = friendId;
+    private ChatRoomCreateReq(List<Long> friendIds, String title) {
+        this.friendIds = friendIds;
         this.title = title;
     }
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomCreateRes.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomCreateRes.java
@@ -10,15 +10,18 @@ import lombok.NoArgsConstructor;
 public class ChatRoomCreateRes {
 
     private Long chatRoomId;
+    private String title;
 
     @Builder
-    private ChatRoomCreateRes(Long chatRoomId) {
+    private ChatRoomCreateRes(Long chatRoomId, String title) {
         this.chatRoomId = chatRoomId;
+        this.title = title;
     }
 
-    public static ChatRoomCreateRes to(Long chatRoomId) {
+    public static ChatRoomCreateRes to(Long chatRoomId, String title) {
         return ChatRoomCreateRes.builder()
             .chatRoomId(chatRoomId)
+            .title(title)
             .build();
     }
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomDetailGetRes.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomDetailGetRes.java
@@ -31,17 +31,18 @@ public class ChatRoomDetailGetRes {
         private String username;
         private String profileImage;
         private String message;
+        private boolean isDeleted;
         private LocalDateTime messageTime;
 
         @Builder
         public ChatRes(Long chatId, Long userId, String username, String profileImage,
-            String message,
-            LocalDateTime messageTime) {
+            String message, boolean isDeleted, LocalDateTime messageTime) {
             this.chatId = chatId;
             this.userId = userId;
             this.username = username;
             this.profileImage = profileImage;
             this.message = message;
+            this.isDeleted = isDeleted;
             this.messageTime = messageTime;
         }
 
@@ -52,6 +53,7 @@ public class ChatRoomDetailGetRes {
                 .username(chat.getSender().getUsername())
                 .profileImage(chat.getSender().getProfileImage())
                 .message(chat.getMessage())
+                .isDeleted(chat.isDeleted())
                 .messageTime(chat.getCreatedAt())
                 .build();
         }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/entity/ChatRoomUser.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/entity/ChatRoomUser.java
@@ -39,4 +39,11 @@ public class ChatRoomUser {
         this.user = user;
         this.chatRoom = chatRoom;
     }
+
+    public static ChatRoomUser to(User user, ChatRoom chatRoom) {
+        return ChatRoomUser.builder()
+            .user(user)
+            .chatRoom(chatRoom)
+            .build();
+    }
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepository.java
@@ -18,4 +18,5 @@ public interface ChatRoomUserRepository extends ChatRoomUserRepositoryCustom {
 
     void delete(ChatRoomUser chatRoomUser);
 
+    List<ChatRoomUser> saveAll(List<ChatRoomUser> chatRoomUsers);
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepository.java
@@ -18,5 +18,5 @@ public interface ChatRoomUserRepository extends ChatRoomUserRepositoryCustom {
 
     void delete(ChatRoomUser chatRoomUser);
 
-    List<ChatRoomUser> saveAll(List<ChatRoomUser> chatRoomUsers);
+    List<ChatRoomUser> saveAll(Iterable<ChatRoomUser> chatRoomUsers);
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
@@ -13,7 +13,7 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Optional<ChatRoom> findChatRoomIdByOnlyTwoUsers(final Long userId1, final Long userId2) {
+    public Optional<ChatRoom> findChatRoomIdByOnlyTwoUsers(final Long userId, final Long friendId) {
         QChatRoomUser chatRoomUser = QChatRoomUser.chatRoomUser;
         QChatRoomUser chatRoomUserSub = new QChatRoomUser("chatRoomUserSub");
 
@@ -26,7 +26,7 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
                         .from(chatRoomUserSub)
                         .groupBy(chatRoomUserSub.chatRoom.id)
                         .having(chatRoomUserSub.user.count().eq(2L))),
-                chatRoomUser.user.id.in(userId1, userId2))
+                chatRoomUser.user.id.in(userId, friendId))
             .fetchOne();
 
         return Optional.ofNullable(chatRoom);

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.clover.youngchat.domain.chatroom.repository;
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
 import com.clover.youngchat.domain.chatroom.entity.QChatRoomUser;
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -17,16 +18,21 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
         QChatRoomUser chatRoomUser = QChatRoomUser.chatRoomUser;
         QChatRoomUser chatRoomUserSub = new QChatRoomUser("chatRoomUserSub");
 
+        // 서브쿼리: 두 사용자가 모두 있는 채팅방 ID 찾기
+        JPQLQuery<Long> subQuery = JPAExpressions
+            .select(chatRoomUserSub.chatRoom.id)
+            .from(chatRoomUserSub)
+            .where(chatRoomUserSub.user.id.in(userId, friendId))
+            .groupBy(chatRoomUserSub.chatRoom.id)
+            .having(chatRoomUserSub.user.id.count().eq(2L));
+
+        // 메인 쿼리: 서브쿼리 결과를 이용하여 ChatRoom 찾기
         ChatRoom chatRoom = queryFactory
             .select(chatRoomUser.chatRoom)
             .from(chatRoomUser)
-            .where(chatRoomUser.chatRoom.in(
-                    JPAExpressions
-                        .select(chatRoomUserSub.chatRoom)
-                        .from(chatRoomUserSub)
-                        .groupBy(chatRoomUserSub.chatRoom.id)
-                        .having(chatRoomUserSub.user.count().eq(2L))),
-                chatRoomUser.user.id.in(userId, friendId))
+            .where(chatRoomUser.chatRoom.id.in(subQuery))
+            .groupBy(chatRoomUser.chatRoom.id)
+            .having(chatRoomUser.user.id.count().eq(2L))
             .fetchOne();
 
         return Optional.ofNullable(chatRoom);

--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -43,8 +43,9 @@ public class ChatRoomService {
         User friend = userRepository.findById(req.getFriendId()).orElseThrow(() ->
             new GlobalException(ResultCode.NOT_FOUND_USER));
 
-        ChatRoom chatRoom = chatRoomUserRepository.findChatRoomIdByOnlyTwoUsers(user.getId(),
-            req.getFriendId()).orElseGet(() -> saveChatRoom(req.getTitle(), user, friend));
+        ChatRoom chatRoom = chatRoomUserRepository
+            .findChatRoomIdByOnlyTwoUsers(user.getId(),
+                req.getFriendId()).orElseGet(() -> saveChatRoom(req.getTitle(), user, friend));
 
         return ChatRoomCreateRes.to(chatRoom.getId());
     }
@@ -119,7 +120,7 @@ public class ChatRoomService {
     }
 
     @Transactional
-    public ChatRoom saveChatRoom(String title, User user, User friend) {
+    protected ChatRoom saveChatRoom(String title, User user, User friend) {
         ChatRoom chatRoom = ChatRoom.builder()
             .title(title)
             .build();

--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -148,11 +148,12 @@ public class ChatRoomService {
         chatRoomRepository.save(chatRoom);
 
         List<ChatRoomUser> chatRoomUsers = new ArrayList<>();
-
         chatRoomUsers.add(ChatRoomUser.to(user, chatRoom));
+
         for (User friend : friends) {
             chatRoomUsers.add(ChatRoomUser.to(friend, chatRoom));
         }
+
         chatRoomUserRepository.saveAll(chatRoomUsers);
 
         return chatRoom;

--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -57,10 +57,10 @@ public class ChatRoomService {
         } else {
             String title =
                 req.getTitle().isBlank() ? setChatRoomTitle(user, friends) : req.getTitle();
-            chatRoom = saveChatRoom(setChatRoomTitle(user, friends), user, friends);
+            chatRoom = saveChatRoom(title, user, friends);
         }
 
-        return ChatRoomCreateRes.to(chatRoom.getId());
+        return ChatRoomCreateRes.to(chatRoom.getId(), chatRoom.getTitle());
     }
 
     @Transactional

--- a/src/test/java/com/clover/youngchat/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chat/service/ChatServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER;
 
-import com.clover.youngchat.domain.chat.constant.ChatConstant;
 import com.clover.youngchat.domain.chat.dto.request.ChatCreateReq;
 import com.clover.youngchat.domain.chat.entity.Chat;
 import com.clover.youngchat.domain.chat.repository.ChatRepository;
@@ -125,7 +124,7 @@ class ChatServiceTest implements ChatTest {
             chatService.deleteChat(TEST_CHAT_ROOM_ID, TEST_CHAT_ID, TEST_USER_ID);
 
             // then
-            assertThat(TEST_CHAT.getMessage()).isEqualTo(ChatConstant.DELETE_MESSAGE);
+            assertThat(TEST_CHAT.isDeleted()).isTrue();
         }
 
         @Test

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/controller/ChatRoomControllerTest.java
@@ -17,6 +17,7 @@ import com.clover.youngchat.domain.chatroom.controller.ChatRoomController;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomCreateReq;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomEditReq;
 import com.clover.youngchat.domain.chatroom.service.ChatRoomService;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -34,7 +35,7 @@ public class ChatRoomControllerTest extends BaseMvcTest {
     void createChatRoom() throws Exception {
         ChatRoomCreateReq req = ChatRoomCreateReq.builder()
             .title(TEST_CHAT_ROOM_TITLE)
-            .friendId(ANOTHER_TEST_USER_ID)
+            .friendIds(List.of(ANOTHER_TEST_USER_ID))
             .build();
 
         mockMvc.perform(post("/api/v1/chat-rooms")

--- a/src/test/java/test/ChatRoomTest.java
+++ b/src/test/java/test/ChatRoomTest.java
@@ -7,6 +7,7 @@ public interface ChatRoomTest extends UserTest {
     Long TEST_CHAT_ROOM_ID = 1L;
     Long TEST_ANOTHER_CHAT_ROOM_ID = 2L;
 
+    String TEST_CHAT_ROOM_TITLE_BLANK = "";
     String TEST_CHAT_ROOM_TITLE = "test title";
     String TEST_ANOTHER_CHAT_ROOM_TITLE = "test title";
 


### PR DESCRIPTION
## 개요
채팅방 생성 로직 및 reqDto 수정

## 작업사항
- 1:1 채팅방 생성시 QueryDsl문 수정
- 채팅방 생성 reqDto 친구 id를 여러개 받아오도록 수정
- 채팅방 생성시 title 필드가 비어있으면 title 지어주는 로직 추가
- 한 채팅방에 여러 사용자가 속할 수 있도록 로직 수정
- CreateChatRoom 테스트코드 수정 및 작성 (추후 QueryDsl에 대한 테스트코드 추가예정)

## 관련 이슈             
`해당 Issue 의 체크리스트를 체크해주세요!`
- close #115 


  
