### PR TITLE
Chat isDeleted 필드 Jackson 매핑시 오류수정

### DIFF
--- a/src/main/java/com/clover/youngchat/domain/chat/dto/response/ChatRes.java
+++ b/src/main/java/com/clover/youngchat/domain/chat/dto/response/ChatRes.java
@@ -38,8 +38,12 @@ public class ChatRes {
             .username(chat.getSender().getUsername())
             .profileImage(chat.getSender().getProfileImage())
             .message(chat.getMessage())
-            .isDeleted(chat.isDeleted())
+            .isDeleted(chat.getIsDeleted())
             .messageTime(chat.getCreatedAt())
             .build();
+    }
+
+    public boolean getIsDeleted() {
+        return this.isDeleted;
     }
 }

--- a/src/main/java/com/clover/youngchat/domain/chat/entity/Chat.java
+++ b/src/main/java/com/clover/youngchat/domain/chat/entity/Chat.java
@@ -45,6 +45,10 @@ public class Chat extends BaseEntity {
         this.chatRoom = chatRoom;
     }
 
+    public boolean getIsDeleted() {
+        return this.isDeleted;
+    }
+
     public void deleteChat() {
         this.isDeleted = true;
     }

--- a/src/test/java/com/clover/youngchat/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chat/service/ChatServiceTest.java
@@ -124,7 +124,7 @@ class ChatServiceTest implements ChatTest {
             chatService.deleteChat(TEST_CHAT_ROOM_ID, TEST_CHAT_ID, TEST_USER_ID);
 
             // then
-            assertThat(TEST_CHAT.isDeleted()).isTrue();
+            assertThat(TEST_CHAT.getIsDeleted()).isTrue();
         }
 
         @Test


### PR DESCRIPTION
## 개요
Chat isDeleted 필드 Jackson 매핑시 오류수정

## 작업사항
- lombok의 @Getter 어노테이션때문에
chat에서 isDeleted란 boolean 필드를 Getter로 가져올때 getIsDeleted()를 isDeleted() 로 가져옵니다. 
Dto또한 마찬가지인데요. dto에서 이부분을 isDeleted 라고 필드명을 변경해도, 
응답값이 직렬화되어 Json으로 매핑될 때 Jackson이 이러한 부분때문에 isDeleted 필드를 deleted라고 인식을 합니다. 

코드 작성시 entity와 dto의 필드를 일치해줄 필요가 있다 생각해 
Dto의 deleted를 isDeleted로 수정했고, Jackson이 잘못 매핑하지 않게 getIsDeleted() 라는 Getter 메서드를 추가했습니다.

## 관련 이슈             
`해당 Issue 의 체크리스트를 체크해주세요!`
- close #136 


  
