### PR TITLE
[#193] Chore: CD 파일 docker compose 명령어 -d 제거

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -76,4 +76,4 @@ jobs:
           key: ${{ secrets.EC2_KEY }}
           script: |
             sudo docker-compose -f $COMPOSE down
-            sudo docker-compose -f $COMPOSE up -d
+            sudo docker-compose -f $COMPOSE up


### PR DESCRIPTION
## 개요
 CD 파일 docker compose 명령어 -d 제거

## 작업사항
- compose up 명령어 실행 시 -d 옵션을 제거합니다.

## 관련 이슈             
- #193 


  
