### PR TITLE
알림 보내기 내부 Query로직 개선

### DIFF
--- a/src/main/java/com/clover/youngchat/domain/chat/service/ChatService.java
+++ b/src/main/java/com/clover/youngchat/domain/chat/service/ChatService.java
@@ -90,7 +90,7 @@ public class ChatService {
     }
 
     private List<Long> getUserIdListByChatRoomId(Long chatRoomId, Long userId) {
-        return chatRoomUserRepository.findUserIdByChatRoomId(chatRoomId, userId)
+        return chatRoomUserRepository.getOtherUsersInChatRoom(chatRoomId, userId)
             .orElseThrow(() -> new GlobalException(NOT_FOUND_CHATROOM));
     }
 }

--- a/src/main/java/com/clover/youngchat/domain/chat/service/ChatService.java
+++ b/src/main/java/com/clover/youngchat/domain/chat/service/ChatService.java
@@ -59,7 +59,7 @@ public class ChatService {
 
         rabbitTemplate.convertAndSend(exchangeName, "chat-rooms." + chatRoomId, ChatRes.to(chat));
 
-        List<Long> userIds = getUserIdListByChatRoomId(chatRoomId);
+        List<Long> userIds = getUserIdListByChatRoomId(chatRoomId, user.getId());
 
         sendMessagesToUsers(userIds);
 
@@ -82,14 +82,9 @@ public class ChatService {
         return new ChatDeleteRes();
     }
 
-    private List<Long> getUserIdListByChatRoomId(Long chatRoomId) {
-        List<ChatRoomUser> chatRoomUsers = chatRoomUserRepository.findChatRoomUserByChatRoomId(
-                chatRoomId)
+    private List<Long> getUserIdListByChatRoomId(Long chatRoomId, Long userId) {
+        return chatRoomUserRepository.findUserIdByChatRoomId(chatRoomId, userId)
             .orElseThrow(() -> new GlobalException(NOT_FOUND_CHATROOM));
-
-        return chatRoomUsers.stream()
-            .map(chatRoomUser -> chatRoomUser.getUser().getId())
-            .toList();
     }
 
     private void sendMessagesToUsers(List<Long> userIds) {

--- a/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatAlertRes.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatAlertRes.java
@@ -1,0 +1,35 @@
+package com.clover.youngchat.domain.chatroom.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatAlertRes {
+
+    private String chatRoomName;
+    private String username;
+    private String profileImage;
+    private String message;
+
+    @Builder
+    private ChatAlertRes(String chatRoomName, String username, String profileImage,
+        String message) {
+        this.chatRoomName = chatRoomName;
+        this.username = username;
+        this.profileImage = profileImage;
+        this.message = message;
+    }
+
+    public static ChatAlertRes to(String chatRoomName, String username, String profileImage,
+        String message) {
+        return ChatAlertRes.builder()
+            .chatRoomName(chatRoomName)
+            .username(username)
+            .profileImage(profileImage)
+            .message(message)
+            .build();
+    }
+}

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepository.java
@@ -18,7 +18,5 @@ public interface ChatRoomUserRepository extends ChatRoomUserRepositoryCustom {
 
     void delete(ChatRoomUser chatRoomUser);
 
-    Optional<List<ChatRoomUser>> findChatRoomUserByChatRoomId(Long chatRoomId);
-
     List<ChatRoomUser> saveAll(Iterable<ChatRoomUser> chatRoomUsers);
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryCustom.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.clover.youngchat.domain.chatroom.repository;
 
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface ChatRoomUserRepositoryCustom {
 
     Optional<ChatRoom> findChatRoomIdByOnlyTwoUsers(Long userId1, Long userId2);
+
+    Optional<List<Long>> findUserIdByChatRoomId(Long chatRoomId, Long userId);
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryCustom.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryCustom.java
@@ -10,5 +10,5 @@ public interface ChatRoomUserRepositoryCustom {
 
     Optional<ChatRoom> findChatRoomIdByOnlyTwoUsers(Long userId1, Long userId2);
 
-    Optional<List<Long>> findUserIdByChatRoomId(Long chatRoomId, Long userId);
+    Optional<List<Long>> getOtherUsersInChatRoom(Long chatRoomId, Long userId);
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
@@ -2,9 +2,11 @@ package com.clover.youngchat.domain.chatroom.repository;
 
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
 import com.clover.youngchat.domain.chatroom.entity.QChatRoomUser;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
@@ -36,5 +38,18 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
             .fetchOne();
 
         return Optional.ofNullable(chatRoom);
+    }
+
+    @Override
+    public Optional<List<Long>> findUserIdByChatRoomId(Long chatRoomId, Long userId) {
+        QChatRoomUser chatRoomUser = QChatRoomUser.chatRoomUser;
+
+        return Optional.ofNullable(
+            queryFactory.select(Projections.constructor(Long.class, chatRoomUser.user.id))
+                .from(chatRoomUser)
+                .where(chatRoomUser.chatRoom.id.in(chatRoomId))
+                .groupBy(chatRoomUser.user.id)
+                .having(chatRoomUser.user.id.notIn(userId))
+                .fetch());
     }
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
@@ -41,7 +41,7 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
     }
 
     @Override
-    public Optional<List<Long>> findUserIdByChatRoomId(Long chatRoomId, Long userId) {
+    public Optional<List<Long>> getOtherUsersInChatRoom(Long chatRoomId, Long userId) {
         QChatRoomUser chatRoomUser = QChatRoomUser.chatRoomUser;
 
         return Optional.ofNullable(


### PR DESCRIPTION
## 개요
알림 보내기 내부 Query로직 개선

## 작업사항
- [x] 기존 메세지 보내기 API에 메시지를 받은 유저에게 알림 보내기 추가 

- [x] 알림 보내기 내부 Query로직 개선

- [x] 메세지를 보낸 자신의 ID는 미포함 로직 추가 

## 관련 이슈             
`해당 Issue 의 체크리스트를 체크해주세요!`
- close #218 


  
