### PR TITLE
채팅방 상세조회 페이지네이션 역순으로 변경

### DIFF
--- a/src/main/java/com/clover/youngchat/domain/chat/repository/ChatRepositoryImpl.java
+++ b/src/main/java/com/clover/youngchat/domain/chat/repository/ChatRepositoryImpl.java
@@ -6,7 +6,6 @@ import com.clover.youngchat.domain.user.entity.QUser;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -20,16 +19,17 @@ public class ChatRepositoryImpl implements ChatRepositoryCustom {
 
     @Override
     public Slice<ChatRes> findChatsByChatRoomId(Long chatRoomId, Long lastChatId, int limitSize) {
-        List<ChatRes> chats = queryChats(chatRoomId, lastChatId, limitSize);
+        List<ChatRes> chats = fetchChatsCursorPagination(chatRoomId, lastChatId, limitSize);
         return createSlice(chats, limitSize);
     }
 
-    private List<ChatRes> queryChats(Long chatRoomId, Long lastChatId, int limitSize) {
+    private List<ChatRes> fetchChatsCursorPagination(Long chatRoomId, Long lastChatId,
+        int limitSize) {
         QChat chat = QChat.chat;
         QUser user = QUser.user;
         BooleanExpression queryCondition = createQueryCondition(chat, chatRoomId, lastChatId);
 
-        List<ChatRes> chats = queryFactory
+        return queryFactory
             .select(Projections.constructor(
                 ChatRes.class,
                 chat.id,
@@ -43,12 +43,8 @@ public class ChatRepositoryImpl implements ChatRepositoryCustom {
             .leftJoin(chat.sender, user)
             .where(queryCondition)
             .orderBy(chat.id.desc())
-            .limit(limitSize + 1)
+            .limit(limitSize + 1) // 다음페이지가 있는지 확인하기 위해 +1 조회
             .fetch();
-
-        Collections.reverse(chats);
-
-        return chats;
     }
 
     private BooleanExpression createQueryCondition(QChat chat, Long chatRoomId, Long lastChatId) {
@@ -62,7 +58,7 @@ public class ChatRepositoryImpl implements ChatRepositoryCustom {
     private Slice<ChatRes> createSlice(List<ChatRes> chats, int limitSize) {
         boolean hasNext = chats.size() > limitSize;
         if (hasNext) {
-            chats.remove(0);
+            chats.remove(limitSize); // 하나더 가져온 값 제거
         }
         return new SliceImpl<>(chats, PageRequest.of(0, limitSize), hasNext);
     }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -35,6 +35,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ChatRoomService {
 
+    private static final int LIMIT_SIZE = 10;
+
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomUserRepository chatRoomUserRepository;
     private final ChatRepository chatRepository;
@@ -129,6 +131,23 @@ public class ChatRoomService {
             .build();
     }
 
+    @Transactional(readOnly = true)
+    public ChatRoomPaginationDetailGetRes getPaginationDetailChatRoom(Long chatRoomId,
+        Long lastChatId,
+        User user) {
+        // 채팅방에 속한 사람만 조회 가능
+        isChatRoomMember(chatRoomId, user.getId());
+        ChatRoom chatRoom = findById(chatRoomId);
+
+        Slice<ChatRes> chatResList =
+            chatRepository.findChatsByChatRoomId(chatRoomId, lastChatId, LIMIT_SIZE);
+
+        return ChatRoomPaginationDetailGetRes.builder()
+            .title(chatRoom.getTitle())
+            .chatResList(chatResList)
+            .build();
+    }
+
     private ChatRoom findById(Long chatRoomId) {
         return chatRoomRepository.findById(chatRoomId).orElseThrow(() ->
             new GlobalException(NOT_FOUND_CHATROOM));
@@ -165,23 +184,5 @@ public class ChatRoomService {
         if (!chatRoomUserRepository.existsByChatRoom_IdAndUser_Id(chatRoomId, userId)) {
             throw new GlobalException(ACCESS_DENY);
         }
-    }
-
-    @Transactional(readOnly = true)
-    public ChatRoomPaginationDetailGetRes getPaginationDetailChatRoom(Long chatRoomId,
-        Long lastChatId,
-        User user) {
-        // 채팅방에 속한 사람만 조회 가능
-        isChatRoomMember(chatRoomId, user.getId());
-        ChatRoom chatRoom = findById(chatRoomId);
-
-        int LIMIT_SIZE = 10;
-        Slice<ChatRes> chatResList =
-            chatRepository.findChatsByChatRoomId(chatRoomId, lastChatId, LIMIT_SIZE);
-
-        return ChatRoomPaginationDetailGetRes.builder()
-            .title(chatRoom.getTitle())
-            .chatResList(chatResList)
-            .build();
     }
 }


### PR DESCRIPTION
## 개요
채팅방 상세조회 페이지네이션 역순으로 변경

## 작업사항
- 채팅방 상세조회 페이지네이션 역순으로 변경
- 상세조회 메서드 위치변경 및 상수변수 메서드 밖으로 이동

## 관련 이슈             
`해당 Issue 의 체크리스트를 체크해주세요!`
- close #95 


  
