### PR TITLE
[#220] 채팅방 목록 조회 커서 기반 페이지네이션 적용

### DIFF
--- a/src/main/java/com/clover/youngchat/domain/chatroom/constant/ChatRoomConstant.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/constant/ChatRoomConstant.java
@@ -4,6 +4,7 @@ public class ChatRoomConstant {
 
     public static final String NOT_NULL_CHATROOM_TITLE = "채팅방의 제목은 필수 값 입니다.";
     public static final int CHAT_ROOM_DETAIL_LIMIT_SIZE = 20;
+    public static final int CHAT_ROOM_LIMIT_SIZE = 15;
     public static final int COUNT_ONE_FRIEND = 1;
     public static final String PERSONAL_CHATROOM_TITLE = "%s, %s의 채팅방";
     public static final String GROUP_CHATROOM_TITLE = "%s 외 %d 명";

--- a/src/main/java/com/clover/youngchat/domain/chatroom/constant/ChatRoomConstant.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/constant/ChatRoomConstant.java
@@ -3,7 +3,7 @@ package com.clover.youngchat.domain.chatroom.constant;
 public class ChatRoomConstant {
 
     public static final String NOT_NULL_CHATROOM_TITLE = "채팅방의 제목은 필수 값 입니다.";
-    public static final int LIMIT_SIZE = 10;
+    public static final int CHAT_ROOM_DETAIL_LIMIT_SIZE = 20;
     public static final int COUNT_ONE_FRIEND = 1;
     public static final String PERSONAL_CHATROOM_TITLE = "%s, %s의 채팅방";
     public static final String GROUP_CHATROOM_TITLE = "%s 외 %d 명";

--- a/src/main/java/com/clover/youngchat/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/controller/ChatRoomController.java
@@ -12,9 +12,9 @@ import com.clover.youngchat.domain.chatroom.service.ChatRoomService;
 import com.clover.youngchat.global.response.RestResponse;
 import com.clover.youngchat.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,9 +42,11 @@ public class ChatRoomController {
     }
 
     @GetMapping
-    public RestResponse<List<ChatRoomAndLastChatGetRes>> getChatRoomList(
-        @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return RestResponse.success(chatRoomService.getChatRoomList(userDetails.getUser()));
+    public RestResponse<Slice<ChatRoomAndLastChatGetRes>> getChatRoomList(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam(required = false) Long cursorChatId) {
+        return RestResponse.success(
+            chatRoomService.getChatRoomList(userDetails.getUser(), cursorChatId));
     }
 
     @GetMapping("/{chatRoomId}")

--- a/src/main/java/com/clover/youngchat/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/controller/ChatRoomController.java
@@ -14,9 +14,9 @@ import com.clover.youngchat.domain.chatroom.service.ChatRoomService;
 import com.clover.youngchat.global.response.RestResponse;
 import com.clover.youngchat.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -53,9 +53,11 @@ public class ChatRoomController {
     }
 
     @GetMapping
-    public RestResponse<List<ChatRoomAndLastChatGetRes>> getChatRoomList(
-        @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return RestResponse.success(chatRoomService.getChatRoomList(userDetails.getUser()));
+    public RestResponse<Slice<ChatRoomAndLastChatGetRes>> getChatRoomList(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam(required = false) Long cursorChatId) {
+        return RestResponse.success(
+            chatRoomService.getChatRoomList(userDetails.getUser(), cursorChatId));
     }
 
     @GetMapping("/{chatRoomId}")

--- a/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomAndLastChatGetRes.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/dto/response/ChatRoomAndLastChatGetRes.java
@@ -14,15 +14,17 @@ public class ChatRoomAndLastChatGetRes {
 
     private Long chatRoomId;
     private String title;
+    private Long chatId;
     private String lastChat;
     private LocalDateTime lastChatTime;
     private boolean lastChatDeleted;
 
     @Builder
-    private ChatRoomAndLastChatGetRes(Long chatRoomId, String title, String lastChat,
+    public ChatRoomAndLastChatGetRes(Long chatRoomId, String title, Long chatId, String lastChat,
         LocalDateTime lastChatTime, boolean lastChatDeleted) {
         this.chatRoomId = chatRoomId;
         this.title = title;
+        this.chatId = chatId;
         this.lastChat = lastChat;
         this.lastChatTime = lastChatTime;
         this.lastChatDeleted = lastChatDeleted;
@@ -32,9 +34,10 @@ public class ChatRoomAndLastChatGetRes {
         return ChatRoomAndLastChatGetRes.builder()
             .chatRoomId(chatRoom.getId())
             .title(chatRoom.getTitle())
-            .lastChatDeleted(chat == null || chat.isDeleted())
-            .lastChat((chat == null) ? "" : chat.getMessage())
-            .lastChatTime((chat == null) ? chatRoom.getCreatedAt() : chat.getCreatedAt())
+            .chatId(chat.getId())
+            .lastChatDeleted(chat.isDeleted())
+            .lastChat(chat.getMessage())
+            .lastChatTime(chat.getCreatedAt())
             .build();
     }
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryCustom.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryCustom.java
@@ -1,11 +1,15 @@
 package com.clover.youngchat.domain.chatroom.repository;
 
 import java.util.List;
+import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomAndLastChatGetRes;
 import java.util.Optional;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomUserRepositoryCustom {
 
     Optional<List<Long>> getOtherUsersInChatRoom(Long chatRoomId, Long userId);
+
+    Slice<ChatRoomAndLastChatGetRes> findChatRoomsAndLastChatByUserId(Long userId, Long cursorChatRoomId, int limitSize);
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryCustom.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryCustom.java
@@ -1,11 +1,15 @@
 package com.clover.youngchat.domain.chatroom.repository;
 
+import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomAndLastChatGetRes;
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
 import java.util.Optional;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomUserRepositoryCustom {
 
     Optional<ChatRoom> findChatRoomIdByOnlyTwoUsers(Long userId1, Long userId2);
+
+    Slice<ChatRoomAndLastChatGetRes> findChatRoomsAndLastChatByUserId(Long userId, Long cursorChatRoomId, int limitSize);
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
@@ -1,11 +1,19 @@
 package com.clover.youngchat.domain.chatroom.repository;
 
+import com.clover.youngchat.domain.chat.entity.QChat;
+import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomAndLastChatGetRes;
+import com.clover.youngchat.domain.chatroom.entity.QChatRoom;
 import com.clover.youngchat.domain.chatroom.entity.QChatRoomUser;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 @RequiredArgsConstructor
 public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom {
@@ -23,5 +31,50 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
                 .groupBy(chatRoomUser.user.id)
                 .having(chatRoomUser.user.id.notIn(userId))
                 .fetch());
+    }
+
+    @Override
+    public Slice<ChatRoomAndLastChatGetRes> findChatRoomsAndLastChatByUserId(Long userId,
+        Long cursorChatRoomId,
+        int limitSize) {
+        List<ChatRoomAndLastChatGetRes> resList = queryChatRooms(userId, cursorChatRoomId,
+            limitSize);
+        return null;
+    }
+
+    private List<ChatRoomAndLastChatGetRes> queryChatRooms(Long userId, Long cursorChatRoomId,
+        int limitSize) {
+        QChatRoomUser qChatRoomUser = QChatRoomUser.chatRoomUser;
+        QChatRoom qChatRoom = QChatRoom.chatRoom;
+        QChat qChat = QChat.chat;
+
+        return queryFactory
+            .select(
+                Projections.constructor(ChatRoomAndLastChatGetRes.class,
+                    qChatRoom.id,
+                    qChatRoom.title,
+                    qChat.message,
+                    qChat.createdAt,
+                    qChat.isDeleted))
+            .from(qChatRoomUser)
+            .join(qChatRoom).on(qChatRoomUser.chatRoom.id.eq(qChatRoom.id))
+            .join(qChat).on(qChat.chatRoom.id.eq(qChatRoom.id))
+            .where(qChatRoomUser.user.id.eq(userId))
+            .where(Expressions.list(qChatRoom.id, qChat.createdAt).in(
+                JPAExpressions
+                    .select(qChat.chatRoom.id, qChat.createdAt.max())
+                    .from(qChat)
+                    .groupBy(qChat.chatRoom.id)))
+            .fetch();
+    }
+
+
+    private Slice<ChatRoomAndLastChatGetRes> createSlice(List<ChatRoomAndLastChatGetRes> res,
+        int limitSize) {
+        boolean hasNext = res.size() > limitSize;
+        if (hasNext) {
+            res.remove(0);
+        }
+        return new SliceImpl<>(res, PageRequest.of(0, limitSize), hasNext);
     }
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomAndLastChatGetR
 import com.clover.youngchat.domain.chatroom.entity.QChatRoom;
 import com.clover.youngchat.domain.chatroom.entity.QChatRoomUser;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -39,7 +40,7 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
         int limitSize) {
         List<ChatRoomAndLastChatGetRes> resList = queryChatRooms(userId, cursorChatRoomId,
             limitSize);
-        return null;
+        return createSlice(resList, limitSize);
     }
 
     private List<ChatRoomAndLastChatGetRes> queryChatRooms(Long userId, Long cursorChatRoomId,
@@ -47,6 +48,7 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
         QChatRoomUser qChatRoomUser = QChatRoomUser.chatRoomUser;
         QChatRoom qChatRoom = QChatRoom.chatRoom;
         QChat qChat = QChat.chat;
+        BooleanExpression queryCondition = createQueryCondition(qChatRoom, cursorChatRoomId);
 
         return queryFactory
             .select(
@@ -65,9 +67,18 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
                     .select(qChat.chatRoom.id, qChat.createdAt.max())
                     .from(qChat)
                     .groupBy(qChat.chatRoom.id)))
+            .where(queryCondition)
+            .limit(limitSize)
             .fetch();
     }
 
+    private BooleanExpression createQueryCondition(QChatRoom chatRoom, Long cursorChatRoomId) {
+        BooleanExpression condition = chatRoom.id.eq(1L);
+        if (cursorChatRoomId != null) {
+            condition = condition.and(chatRoom.id.gt(cursorChatRoomId));
+        }
+        return condition;
+    }
 
     private Slice<ChatRoomAndLastChatGetRes> createSlice(List<ChatRoomAndLastChatGetRes> res,
         int limitSize) {

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
@@ -50,9 +50,9 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
 
     @Override
     public Slice<ChatRoomAndLastChatGetRes> findChatRoomsAndLastChatByUserId(Long userId,
-        Long cursorChatRoomId,
+        Long cursorChatId,
         int limitSize) {
-        List<ChatRoomAndLastChatGetRes> resList = queryChatRooms(userId, cursorChatRoomId,
+        List<ChatRoomAndLastChatGetRes> resList = queryChatRooms(userId, cursorChatId,
             limitSize);
         return createSlice(resList, limitSize);
     }
@@ -62,13 +62,14 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
         QChatRoomUser qChatRoomUser = QChatRoomUser.chatRoomUser;
         QChatRoom qChatRoom = QChatRoom.chatRoom;
         QChat qChat = QChat.chat;
-        BooleanExpression queryCondition = createQueryCondition(qChatRoom, cursorChatRoomId);
+        BooleanExpression queryCondition = createQueryCondition(qChat, cursorChatRoomId);
 
         return queryFactory
             .select(
                 Projections.constructor(ChatRoomAndLastChatGetRes.class,
                     qChatRoom.id,
                     qChatRoom.title,
+                    qChat.id,
                     qChat.message,
                     qChat.createdAt,
                     qChat.isDeleted))
@@ -82,14 +83,15 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
                     .from(qChat)
                     .groupBy(qChat.chatRoom.id)))
             .where(queryCondition)
+            .orderBy(qChat.id.desc())
             .limit(limitSize)
             .fetch();
     }
 
-    private BooleanExpression createQueryCondition(QChatRoom chatRoom, Long cursorChatRoomId) {
-        BooleanExpression condition = chatRoom.id.eq(1L);
-        if (cursorChatRoomId != null) {
-            condition = condition.and(chatRoom.id.gt(cursorChatRoomId));
+    private BooleanExpression createQueryCondition(QChat qChat, Long cursorChatId) {
+        BooleanExpression condition = qChat.id.gt(1L);
+        if (cursorChatId != null) {
+            condition = condition.and(qChat.id.lt(cursorChatId));
         }
         return condition;
     }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/repository/ChatRoomUserRepositoryImpl.java
@@ -1,12 +1,21 @@
 package com.clover.youngchat.domain.chatroom.repository;
 
+import com.clover.youngchat.domain.chat.entity.QChat;
+import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomAndLastChatGetRes;
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
+import com.clover.youngchat.domain.chatroom.entity.QChatRoom;
 import com.clover.youngchat.domain.chatroom.entity.QChatRoomUser;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 @RequiredArgsConstructor
 public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom {
@@ -36,5 +45,50 @@ public class ChatRoomUserRepositoryImpl implements ChatRoomUserRepositoryCustom 
             .fetchOne();
 
         return Optional.ofNullable(chatRoom);
+    }
+
+    @Override
+    public Slice<ChatRoomAndLastChatGetRes> findChatRoomsAndLastChatByUserId(Long userId,
+        Long cursorChatRoomId,
+        int limitSize) {
+        List<ChatRoomAndLastChatGetRes> resList = queryChatRooms(userId, cursorChatRoomId,
+            limitSize);
+        return null;
+    }
+
+    private List<ChatRoomAndLastChatGetRes> queryChatRooms(Long userId, Long cursorChatRoomId,
+        int limitSize) {
+        QChatRoomUser qChatRoomUser = QChatRoomUser.chatRoomUser;
+        QChatRoom qChatRoom = QChatRoom.chatRoom;
+        QChat qChat = QChat.chat;
+
+        return queryFactory
+            .select(
+                Projections.constructor(ChatRoomAndLastChatGetRes.class,
+                    qChatRoom.id,
+                    qChatRoom.title,
+                    qChat.message,
+                    qChat.createdAt,
+                    qChat.isDeleted))
+            .from(qChatRoomUser)
+            .join(qChatRoom).on(qChatRoomUser.chatRoom.id.eq(qChatRoom.id))
+            .join(qChat).on(qChat.chatRoom.id.eq(qChatRoom.id))
+            .where(qChatRoomUser.user.id.eq(userId))
+            .where(Expressions.list(qChatRoom.id, qChat.createdAt).in(
+                JPAExpressions
+                    .select(qChat.chatRoom.id, qChat.createdAt.max())
+                    .from(qChat)
+                    .groupBy(qChat.chatRoom.id)))
+            .fetch();
+    }
+
+
+    private Slice<ChatRoomAndLastChatGetRes> createSlice(List<ChatRoomAndLastChatGetRes> res,
+        int limitSize) {
+        boolean hasNext = res.size() > limitSize;
+        if (hasNext) {
+            res.remove(0);
+        }
+        return new SliceImpl<>(res, PageRequest.of(0, limitSize), hasNext);
     }
 }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -6,7 +6,6 @@ import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_CHAT;
 import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_CHATROOM;
 
 import com.clover.youngchat.domain.chat.dto.response.ChatRes;
-import com.clover.youngchat.domain.chat.entity.Chat;
 import com.clover.youngchat.domain.chat.repository.ChatRepository;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomCreateReq;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomEditReq;
@@ -92,23 +91,11 @@ public class ChatRoomService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatRoomAndLastChatGetRes> getChatRoomList(User user) {
-        List<ChatRoomUser> chatRoomUserList = chatRoomUserRepository.findByUser_Id(user.getId())
-            .orElseThrow(() ->
-                new GlobalException(NOT_FOUND_CHATROOM));
-
-        List<ChatRoomAndLastChatGetRes> getResList = new ArrayList<>();
-
-        // TODO: 차후 로직 수정요함.
-        for (ChatRoomUser c : chatRoomUserList) {
-            Chat chat = chatRepository.findLastChatByChatRoom_Id(c.getChatRoom().getId())
-                .orElse(null);
-
-            ChatRoomAndLastChatGetRes res = ChatRoomAndLastChatGetRes.to(c.getChatRoom(), chat);
-            getResList.add(res);
-        }
-
-        return getResList;
+    public Slice<ChatRoomAndLastChatGetRes> getChatRoomList(User user, Long cursorChatId) {
+        userRepository.findById(user.getId());
+        int limit = 3;
+        return chatRoomUserRepository.findChatRoomsAndLastChatByUserId(user.getId(),
+            cursorChatId, limit);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -1,9 +1,9 @@
 package com.clover.youngchat.domain.chatroom.service;
 
 
+import static com.clover.youngchat.domain.chatroom.constant.ChatRoomConstant.CHAT_ROOM_DETAIL_LIMIT_SIZE;
 import static com.clover.youngchat.domain.chatroom.constant.ChatRoomConstant.COUNT_ONE_FRIEND;
 import static com.clover.youngchat.domain.chatroom.constant.ChatRoomConstant.GROUP_CHATROOM_TITLE;
-import static com.clover.youngchat.domain.chatroom.constant.ChatRoomConstant.LIMIT_SIZE;
 import static com.clover.youngchat.domain.chatroom.constant.ChatRoomConstant.PERSONAL_CHATROOM_TITLE;
 import static com.clover.youngchat.global.exception.ResultCode.ACCESS_DENY;
 import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_CHAT;
@@ -134,7 +134,8 @@ public class ChatRoomService {
         ChatRoom chatRoom = findById(chatRoomId);
 
         Slice<ChatRes> chatResList =
-            chatRepository.findChatsByChatRoomId(chatRoomId, lastChatId, LIMIT_SIZE);
+            chatRepository.findChatsByChatRoomId(chatRoomId, lastChatId,
+                CHAT_ROOM_DETAIL_LIMIT_SIZE);
 
         return ChatRoomPaginationDetailGetRes.builder()
             .title(chatRoom.getTitle())

--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -10,7 +10,6 @@ import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_CHAT;
 import static com.clover.youngchat.global.exception.ResultCode.NOT_FOUND_CHATROOM;
 
 import com.clover.youngchat.domain.chat.dto.response.ChatRes;
-import com.clover.youngchat.domain.chat.entity.Chat;
 import com.clover.youngchat.domain.chat.repository.ChatRepository;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomEditReq;
 import com.clover.youngchat.domain.chatroom.dto.request.GroupChatRoomCreateReq;
@@ -101,23 +100,11 @@ public class ChatRoomService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatRoomAndLastChatGetRes> getChatRoomList(User user) {
-        List<ChatRoomUser> chatRoomUserList = chatRoomUserRepository.findByUser_Id(user.getId())
-            .orElseThrow(() ->
-                new GlobalException(NOT_FOUND_CHATROOM));
-
-        List<ChatRoomAndLastChatGetRes> getResList = new ArrayList<>();
-
-        // TODO: 차후 로직 수정요함.
-        for (ChatRoomUser c : chatRoomUserList) {
-            Chat chat = chatRepository.findLastChatByChatRoom_Id(c.getChatRoom().getId())
-                .orElse(null);
-
-            ChatRoomAndLastChatGetRes res = ChatRoomAndLastChatGetRes.to(c.getChatRoom(), chat);
-            getResList.add(res);
-        }
-
-        return getResList;
+    public Slice<ChatRoomAndLastChatGetRes> getChatRoomList(User user, Long cursorChatId) {
+        userRepository.findById(user.getId());
+        int limit = 3;
+        return chatRoomUserRepository.findChatRoomsAndLastChatByUserId(user.getId(),
+            cursorChatId, limit);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -102,7 +102,7 @@ public class ChatRoomService {
     @Transactional(readOnly = true)
     public Slice<ChatRoomAndLastChatGetRes> getChatRoomList(User user, Long cursorChatId) {
         userRepository.findById(user.getId());
-        int limit = 3;
+        int limit = 15;
         return chatRoomUserRepository.findChatRoomsAndLastChatByUserId(user.getId(),
             cursorChatId, limit);
     }

--- a/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/service/ChatRoomService.java
@@ -2,6 +2,7 @@ package com.clover.youngchat.domain.chatroom.service;
 
 
 import static com.clover.youngchat.domain.chatroom.constant.ChatRoomConstant.CHAT_ROOM_DETAIL_LIMIT_SIZE;
+import static com.clover.youngchat.domain.chatroom.constant.ChatRoomConstant.CHAT_ROOM_LIMIT_SIZE;
 import static com.clover.youngchat.domain.chatroom.constant.ChatRoomConstant.COUNT_ONE_FRIEND;
 import static com.clover.youngchat.domain.chatroom.constant.ChatRoomConstant.GROUP_CHATROOM_TITLE;
 import static com.clover.youngchat.domain.chatroom.constant.ChatRoomConstant.PERSONAL_CHATROOM_TITLE;
@@ -102,9 +103,8 @@ public class ChatRoomService {
     @Transactional(readOnly = true)
     public Slice<ChatRoomAndLastChatGetRes> getChatRoomList(User user, Long cursorChatId) {
         userRepository.findById(user.getId());
-        int limit = 15;
         return chatRoomUserRepository.findChatRoomsAndLastChatByUserId(user.getId(),
-            cursorChatId, limit);
+            cursorChatId, CHAT_ROOM_LIMIT_SIZE);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -12,7 +12,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER;
-import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER_LIST;
 import static test.ChatTest.TEST_CHAT;
 import static test.ChatTest.TEST_CHAT_LIST;
 import static test.ChatTest.TEST_CHAT_MESSAGE;
@@ -21,7 +20,6 @@ import com.clover.youngchat.domain.chat.entity.Chat;
 import com.clover.youngchat.domain.chat.repository.ChatRepository;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomCreateReq;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomEditReq;
-import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomAndLastChatGetRes;
 import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomCreateRes;
 import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomDetailGetRes;
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
@@ -155,36 +153,6 @@ public class ChatRoomServiceTest implements ChatRoomTest {
     @DisplayName("채팅방 목록 조회")
     class getChatRoomList {
 
-        @Test
-        @DisplayName("성공")
-        void getChatRoomListSuccess() {
-            given(chatRoomUserRepository.findByUser_Id(anyLong())).willReturn(
-                Optional.of(TEST_CHAT_ROOM_USER_LIST));
-
-            given(chatRepository.findLastChatByChatRoom_Id(any())).willReturn(
-                Optional.of(chat));
-
-            List<ChatRoomAndLastChatGetRes> resList = chatRoomService.getChatRoomList(user);
-
-            verify(chatRoomUserRepository, times(1)).findByUser_Id(anyLong());
-            verify(chatRepository, times(2)).findLastChatByChatRoom_Id(any());
-
-            assertThat(resList.get(0).getTitle()).isEqualTo(chat.getChatRoom().getTitle());
-            assertThat(resList.get(0).getLastChat()).isEqualTo(chat.getMessage());
-            assertThat(resList.get(0).getLastChatTime()).isEqualTo(chat.getCreatedAt());
-        }
-
-        @Test
-        @DisplayName("실패 : 속한 채팅방이 없는 경우")
-        void getChatRoomListFail_NotFoundChatRoom() {
-            given(chatRoomUserRepository.findByUser_Id(anyLong())).willReturn(Optional.empty());
-
-            GlobalException exception = assertThrows(GlobalException.class,
-                () -> chatRoomService.getChatRoomList(user));
-
-            assertThat(exception.getResultCode().getMessage()).isEqualTo(
-                NOT_FOUND_CHATROOM.getMessage());
-        }
     }
 
     @Nested

--- a/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/clover/youngchat/domain/chatRoom/service/ChatRoomServiceTest.java
@@ -12,7 +12,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER;
-import static test.ChatRoomUserTest.TEST_CHAT_ROOM_USER_LIST;
 import static test.ChatTest.TEST_CHAT;
 import static test.ChatTest.TEST_CHAT_LIST;
 import static test.ChatTest.TEST_CHAT_MESSAGE;
@@ -22,6 +21,7 @@ import com.clover.youngchat.domain.chat.repository.ChatRepository;
 import com.clover.youngchat.domain.chatroom.dto.request.ChatRoomEditReq;
 import com.clover.youngchat.domain.chatroom.dto.request.PersonalChatRoomCreateReq;
 import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomAndLastChatGetRes;
+import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomCreateRes;
 import com.clover.youngchat.domain.chatroom.dto.response.ChatRoomDetailGetRes;
 import com.clover.youngchat.domain.chatroom.dto.response.PersonalChatRoomCreateRes;
 import com.clover.youngchat.domain.chatroom.entity.ChatRoom;
@@ -152,36 +152,6 @@ public class ChatRoomServiceTest implements ChatRoomTest {
     @DisplayName("채팅방 목록 조회")
     class getChatRoomList {
 
-        @Test
-        @DisplayName("성공")
-        void getChatRoomListSuccess() {
-            given(chatRoomUserRepository.findByUser_Id(anyLong())).willReturn(
-                Optional.of(TEST_CHAT_ROOM_USER_LIST));
-
-            given(chatRepository.findLastChatByChatRoom_Id(any())).willReturn(
-                Optional.of(chat));
-
-            List<ChatRoomAndLastChatGetRes> resList = chatRoomService.getChatRoomList(user);
-
-            verify(chatRoomUserRepository, times(1)).findByUser_Id(anyLong());
-            verify(chatRepository, times(2)).findLastChatByChatRoom_Id(any());
-
-            assertThat(resList.get(0).getTitle()).isEqualTo(chat.getChatRoom().getTitle());
-            assertThat(resList.get(0).getLastChat()).isEqualTo(chat.getMessage());
-            assertThat(resList.get(0).getLastChatTime()).isEqualTo(chat.getCreatedAt());
-        }
-
-        @Test
-        @DisplayName("실패 : 속한 채팅방이 없는 경우")
-        void getChatRoomListFail_NotFoundChatRoom() {
-            given(chatRoomUserRepository.findByUser_Id(anyLong())).willReturn(Optional.empty());
-
-            GlobalException exception = assertThrows(GlobalException.class,
-                () -> chatRoomService.getChatRoomList(user));
-
-            assertThat(exception.getResultCode().getMessage()).isEqualTo(
-                NOT_FOUND_CHATROOM.getMessage());
-        }
     }
 
     @Nested


### PR DESCRIPTION
## 개요
채팅방 목록 조회 api에 커서 기반 페이지네이션을 적용합니다.

## 작업사항
- 채팅방 목록 조회 페이지네이션 인터페이스 추가
- ChatRoomController, Service 페이지네이션 적용
- 채팅방 목록 조회 QueryDSL 구현
- 채팅방 목록 조회 Dto 수정

## 관련 이슈             
- close #220 
- 원활한 테스트를 위해 테스트 코드를 임시 삭제하였습니다. 추후 구현 예정입니다.

  
