### PR TITLE
[#237] Refactor: ChatRoom entity 테이블 명 chatroom 지정

### DIFF
--- a/src/main/java/com/clover/youngchat/domain/chatroom/entity/ChatRoom.java
+++ b/src/main/java/com/clover/youngchat/domain/chatroom/entity/ChatRoom.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chatroom")
 public class ChatRoom extends BaseEntity {
 
     @Id


### PR DESCRIPTION
## 개요
ChatRoom entity의 테이블명이 ChatRoom으로 되어있어 이를 chatroom으로 수정합니다.
![image](https://github.com/Just-Clover/YOUng-chat-backend/assets/109781694/4252fc03-979e-45cb-bb55-3b6d41922081)

## 작업사항
- `@Table` 어노테이션 추가 및 name 지정

## 관련 이슈             
- close #237 


  
